### PR TITLE
Bug: Split GUI and Job into 2 processes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,5 @@ env:
     - TEST_FILE=test_view.py
     - TEST_FILE=test_model.py
     - TEST_FILE=test_controller.py
-before_script:
-    - echo 'export DISPLAY=:0.0' >> ~/.bashrc
 script:
     - python -m pytest test/$TEST_FILE -vv

--- a/src/gui.ui
+++ b/src/gui.ui
@@ -320,7 +320,6 @@
               <object class="ttk.Progressbar" id="Progressbar_1">
                 <property name="length">150</property>
                 <property name="orient">horizontal</property>
-                <property name="value">64</property>
                 <layout>
                   <property name="column">1</property>
                   <property name="propagate">True</property>
@@ -330,7 +329,7 @@
             </child>
             <child>
               <object class="ttk.Button" id="Start">
-                <property name="command">start_job</property>
+                <property name="command">start_btn_handler</property>
                 <property name="default">active</property>
                 <property name="state">normal</property>
                 <property name="takefocus">true</property>

--- a/src/gui.ui
+++ b/src/gui.ui
@@ -323,7 +323,7 @@
                 <layout>
                   <property name="column">1</property>
                   <property name="propagate">True</property>
-                  <property name="row">1</property>
+                  <property name="row">4</property>
                 </layout>
               </object>
             </child>
@@ -350,28 +350,6 @@
                   <property name="column">1</property>
                   <property name="propagate">True</property>
                   <property name="row">0</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="ttk.Progressbar" id="Progressbar_2">
-                <property name="length">150</property>
-                <property name="orient">horizontal</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="propagate">True</property>
-                  <property name="row">4</property>
-                </layout>
-              </object>
-            </child>
-            <child>
-              <object class="ttk.Progressbar" id="Progressbar_3">
-                <property name="length">150</property>
-                <property name="orient">horizontal</property>
-                <layout>
-                  <property name="column">1</property>
-                  <property name="propagate">True</property>
-                  <property name="row">6</property>
                 </layout>
               </object>
             </child>

--- a/src/model.py
+++ b/src/model.py
@@ -34,9 +34,6 @@ class Job:
             self.settings = None
         # disable multiprocessing on mac os
         self.multi = sys.platform != 'darwin'
-        # self.frame_len = 100
-        # self.frame_num = 1
-        self.success = False
 
     def multi_map(self, fxn, arr):
         # Given a function and a list to iterate over, multi_map will attempt
@@ -52,7 +49,7 @@ class Job:
         else:
             return [fxn(elem) for elem in arr]
 
-    def do_the_job(self, queue=None):
+    def do_the_job(self)  # , queue=None):
         video = cv2.VideoCapture(self.video_path)
         video.set(cv2.CAP_PROP_POS_AVI_RATIO, 1)
         mRuntime = video.get(cv2.CAP_PROP_POS_MSEC)
@@ -70,7 +67,6 @@ class Job:
                 f'This time ({timestamp} sec) does not exist in the video.')
             return None
         img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-        # self.frame_num += 1
         return (img, timestamp)
 
     def get_frames(self):

--- a/src/model.py
+++ b/src/model.py
@@ -28,17 +28,15 @@ class Job:
                     self.video_path = yt_vid_path
             else: # if given string was not a YouTube URL
                 self.video_path = settings['video']
-
-            # self.video_path = settings['video']
             self.settings = settings['settings']
-            # self.do_the_job()
         else:
             self.video_path = None
             self.settings = None
         # disable multiprocessing on mac os
         self.multi = sys.platform != 'darwin'
-        self.frame_len = None
-        self.frame_num = 0
+        # self.frame_len = 100
+        # self.frame_num = 1
+        self.success = False
 
     def multi_map(self, fxn, arr):
         # Given a function and a list to iterate over, multi_map will attempt
@@ -54,7 +52,7 @@ class Job:
         else:
             return [fxn(elem) for elem in arr]
 
-    def do_the_job(self):
+    def do_the_job(self, queue=None):
         video = cv2.VideoCapture(self.video_path)
         video.set(cv2.CAP_PROP_POS_AVI_RATIO, 1)
         mRuntime = video.get(cv2.CAP_PROP_POS_MSEC)
@@ -62,6 +60,8 @@ class Job:
         data = self.classify_frames()
         results = self.interpret_results(data, self.settings['conf'])
         self.save_clips(results)
+        # queue.put(1)
+        self.success = True
 
     def get_frame(self, timestamp):
         video = cv2.VideoCapture(self.video_path)

--- a/src/model.py
+++ b/src/model.py
@@ -49,7 +49,7 @@ class Job:
         else:
             return [fxn(elem) for elem in arr]
 
-    def do_the_job(self)  # , queue=None):
+    def do_the_job(self):  # , queue=None):
         video = cv2.VideoCapture(self.video_path)
         video.set(cv2.CAP_PROP_POS_AVI_RATIO, 1)
         mRuntime = video.get(cv2.CAP_PROP_POS_MSEC)

--- a/src/model.py
+++ b/src/model.py
@@ -59,9 +59,7 @@ class Job:
         self.settings['runtime'] = int(mRuntime // 1000)
         data = self.classify_frames()
         results = self.interpret_results(data, self.settings['conf'])
-        self.save_clips(results)
-        # queue.put(1)
-        self.success = True
+        return self.save_clips(results)
 
     def get_frame(self, timestamp):
         video = cv2.VideoCapture(self.video_path)
@@ -72,7 +70,7 @@ class Job:
                 f'This time ({timestamp} sec) does not exist in the video.')
             return None
         img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
-        self.frame_num += 1
+        # self.frame_num += 1
         return (img, timestamp)
 
     def get_frames(self):
@@ -203,8 +201,8 @@ class Job:
 
 
     def save_clips(self, timestamps):
-        return timestamps and self.multi_map(
-            Worker(self.video_path).make_clip, timestamps)
+        return len(timestamps) and len(self.multi_map(
+            Worker(self.video_path).make_clip, timestamps))
 
 
     def kill(self):

--- a/src/model.py
+++ b/src/model.py
@@ -37,6 +37,8 @@ class Job:
             self.settings = None
         # disable multiprocessing on mac os
         self.multi = sys.platform != 'darwin'
+        self.frame_len = None
+        self.frame_num = 0
 
     def multi_map(self, fxn, arr):
         # Given a function and a list to iterate over, multi_map will attempt
@@ -70,6 +72,7 @@ class Job:
                 f'This time ({timestamp} sec) does not exist in the video.')
             return None
         img = Image.fromarray(cv2.cvtColor(frame, cv2.COLOR_BGR2RGB))
+        self.frame_num += 1
         return (img, timestamp)
 
     def get_frames(self):
@@ -85,6 +88,7 @@ class Job:
         timestamps = [time for time in poll_times if time <= runtime]
         frames = self.multi_map(self.get_frame, timestamps)
         frames = [frame for frame in frames if frame]
+        self.frame_len = len(frames)
         return frames
 
     def classify_frame(self, frame):

--- a/src/start.py
+++ b/src/start.py
@@ -1,12 +1,3 @@
-from view import GUI
-import tkinter as tk
-from tkinter.ttk import *
-from ttkthemes import ThemedTk
-
-def render():
-    root = ThemedTk(theme='arc')
-    app = GUI(root)
-    app.get_progress()
-    root.mainloop()
+from view import render
 
 render()

--- a/src/start.py
+++ b/src/start.py
@@ -6,6 +6,7 @@ from ttkthemes import ThemedTk
 def render():
     root = ThemedTk(theme='arc')
     app = GUI(root)
+    app.get_progress()
     root.mainloop()
 
 render()

--- a/src/view.py
+++ b/src/view.py
@@ -30,6 +30,9 @@ class GUI:
         self.job = None
         self.process = None
         self.seer = Seer()
+        self.prog_num = 0
+        self.prog_len = 100
+        self.master = master
 
         # create builder
         self.builder = builder = pygubu.Builder()
@@ -199,8 +202,16 @@ class GUI:
             pbar = self.builder.get_object('Progressbar_1')
             if self.job and self.job.frame_len:
                 job = self.job
+                print(job.frame_num)
                 val = int(round(job.frame_num / job.frame_len, 2) * 100)
                 pbar['value'] = val
+        self.master.after(50, self.get_progress)
+
+        # pbar = self.builder.get_object('Progressbar_1')
+        # self.prog_num += 1
+        # val = min(int(round(self.prog_num / self.prog_len, 2) * 100), 100)
+        # pbar['value'] = val
+        # self.master.after(50, self.get_progress)
 
     def kill_job(self):
         if self.job or self.process:
@@ -289,6 +300,12 @@ class GUI:
             return True
         except:
             return False
+
+def render():
+    root = ThemedTk(theme='arc')
+    app = GUI(root)
+    root.after(50, app.get_progress)
+    root.mainloop()
 
 # multiprocessing checkbox support
 # default is off on mac, on otherwise

--- a/src/view.py
+++ b/src/view.py
@@ -205,28 +205,30 @@ class GUI:
     def get_progress(self):
         pbar = self.builder.get_object('Progressbar_1')
         job = self.job
-        if self.process and self.process.is_alive():
-            # copy_q = copy.deepcopy(self.queue)
-            # if copy_q.get() == 1:
-            if self.job.success:
-                self.job.kill()
+        process = self.process
+        if self.process:
+            exitcode = self.process.exitcode
+            print(exitcode)
+            if exitcode is not None:
                 self.process.terminate()
                 self.process.join()
-                self.update_log('SUCCESS: Job completed.')
+                self.job.kill()
                 self.job = None
                 self.process = None
-                self.kill_job()
+                self.builder.get_object('Start')['text'] = 'Start Job'
+                self.builder.get_object('Status')['text'] = 'Done.'
+                pbar['value'] = 100
+                if exitcode == 0:
+                    self.update_log('SUCCESS: Job completed. No relevant clips found.')
+                else:
+                    self.update_log(f'SUCCESS: Job completed. {exitcode} clips saved in source video path.')
                 return
-            # if self.job.frame_len:
-            #     val = int(round(job.frame_num / job.frame_len, 2) * 100)
-            #     pbar['value'] = val
-
-            # self.prog_num += 1
-            # val = int(round(self.prog_num % 100 / self.prog_len, 2) * 100)
-            # pbar['value'] = val
-
-        # else:
-        #     pbar['value'] = int((self.prog_num / self.prog_len) * 100)
+            else:
+                self.prog_num += 1
+                val = int(round(self.prog_num % 100 / self.prog_len, 2) * 100)
+                pbar['value'] = val
+        else:
+            pbar['value'] = int((self.prog_num / self.prog_len) * 100)
         self.master.after(50, self.get_progress)
 
 

--- a/src/view.py
+++ b/src/view.py
@@ -29,11 +29,11 @@ class GUI:
 
         self.job = None
         self.process = None
-        self.queue = q
         self.seer = Seer()
         self.prog_num = 0
         self.prog_len = 100
         self.master = master
+        # self.queue = q
 
         # create builder
         self.builder = builder = pygubu.Builder()

--- a/src/view.py
+++ b/src/view.py
@@ -8,19 +8,15 @@ import os
 import cv2
 import pygubu
 import re
-import queue
-import time
-from multiprocessing import Queue, Process, Manager
+from multiprocessing import Process  # , Queue, Manager
 import multiprocessing as mp
-import sys
-import copy
 # -*- coding: utf-8 -*-
 
 
 # set the default values for the GUI constructor.
 DEFAULT = {'conf': .5, 'poll': 5, 'anti': 5, 'runtime': 1, 'search': []}
-manager = Manager()
-q = manager.Queue()
+# manager = Manager()
+# q = manager.Queue()
 
 class GUI:
 
@@ -257,20 +253,13 @@ class GUI:
             self.update_log(f'SUCCESS: Processing job with settings: {settings}')
             btn = self.builder.get_object('Start')
             try:
-                # btn.configure(text="Cancel")
                 self.process = Process(target=self.job.do_the_job)#, args=(self.queue,))
                 btn['text'] = 'Cancel'
                 self.builder.get_object('Status')['text'] = 'Working...'
                 self.process.start()
                 self.master.after(50, self.get_progress)
-                # self.process.join()
-                # pbar = self.builder.get_object('Progressbar_1')
-                # # pbar.start(50)
-                # self.get_progress()
-                # success = self.job.do_the_job()
             except Exception as e:
                 self.update_log(f'ERROR: Exception {e} occurred.')
-            # btn['text'] = 'Start Job'
 
 
     def set_settings(self, values, path):
@@ -285,7 +274,6 @@ class GUI:
         if len(extra) > 0:
             self.set_default_settings()
             return False
-        # values['runtime'] = int(values['runtime'])
         try:
             if not (isinstance(values['conf'], (int,float)) and isinstance(values['poll'], int) and isinstance(values['anti'], int) and isinstance(values['runtime'], int)):
                 raise TypeError
@@ -306,9 +294,7 @@ class GUI:
             self.set_default_settings()
             return False
 
-        #print('values: ' + str(values))
         self.settings = values  # be sure that values are always in the same order. Do validation
-        #print('self.settings: ' + str(self.settings))
         self.video_path = path
         # where values is a dictionary
         return True
@@ -337,7 +323,6 @@ def render():
     root = ThemedTk(theme='arc')
     app = GUI(root)
     root.protocol('WM_DELETE_WINDOW', app.close)
-    # root.after(50, app.get_progress)
     root.mainloop()
 
 # multiprocessing checkbox support

--- a/src/view.py
+++ b/src/view.py
@@ -196,17 +196,11 @@ class GUI:
 
     def get_progress(self):
         if self.process and self.process.is_alive():
-            # self.after(50, self.get_progress)
-            time.sleep(1)
-            self.get_progress()
-            return
-        else:
             pbar = self.builder.get_object('Progressbar_1')
             if self.job and self.job.frame_len:
                 job = self.job
                 val = int(round(job.frame_num / job.frame_len, 2) * 100)
                 pbar['value'] = val
-                # pbar.stop()
 
     def kill_job(self):
         if self.job or self.process:
@@ -232,9 +226,9 @@ class GUI:
                 self.process = Process(target=self.job.do_the_job)#, args=(self.queue,))
                 btn['text'] = 'Cancel'
                 self.process.start()
-                pbar = self.builder.get_object('Progressbar_1')
-                # pbar.start(50)
-                self.get_progress()
+                # pbar = self.builder.get_object('Progressbar_1')
+                # # pbar.start(50)
+                # self.get_progress()
                 # success = self.job.do_the_job()
                 self.update_log('SUCCESS: Job completed.')
             except Exception as e:


### PR DESCRIPTION
***For All Submissions:***


*Proposed Changes:*

- > GUI currently freezes when one presses `Start Job`, this PR puts the created job in another process and allows functionality like Cancelling the Job and even loading captions while the job is happening. It also introduces a pseudo-progress bar, which only indicates the Job is processing, not actual numerical progress.


*Testing Instructions:*

* [ ] Does simply running `pytest` suffice?


**Finally**,
* [ ] Have you updated the version number, by running `git tag v0.x`?

------

**For new features:**
* [ ] If you have used new packages, have you remade `requirements.txt` (explained in README)?

**For new tests:**
* [ ] Have you made sure your tests are in the `tests/` dir?
* [ ] Have you made sure your tests are in a file that starts with '`test_`'?
* [ ] Have you made sure your test functions starts with '`test_`'?
